### PR TITLE
🪛Make Embedded Images Editable

### DIFF
--- a/ImageEditor/ImageEditor.html
+++ b/ImageEditor/ImageEditor.html
@@ -33,7 +33,12 @@
         <button id="btnClear" class="svg-button" title="Reset Canvas"></button>
         <button id="btnSave" class="svg-button" title="Finish Editing"></button>
         <script>
+            const urlParams = new URLSearchParams(window.location.search);
             const canvas = new fabric.Canvas('c');
+            console.log(urlParams.get('json'));
+            if (urlParams.get('json')!=""){
+                canvas.loadFromJSON(urlParams.get('json'), canvas.renderAll.bind(canvas));
+            }
             function resizeCanvas() {
                 canvas.setWidth(window.innerWidth);
                 canvas.setHeight(window.innerHeight);

--- a/ImageEditor/imageeditor.js
+++ b/ImageEditor/imageeditor.js
@@ -68,7 +68,8 @@ document.getElementById('btnSave').addEventListener('click', function() {
     const urlParams = new URLSearchParams(window.location.search);
     window.ImageEditorAPI.sendImage({
         id:urlParams.get('id'),
-        data:base64Data
+        data:base64Data,
+        json:canvas.toJSON(),
     });
 });
 

--- a/index.js
+++ b/index.js
@@ -576,7 +576,8 @@ ipcMain.on('openImageEditor', async(event,data) => {
     });
     childWindow.loadFile("ImageEditor/ImageEditor.html",{
       query:{
-        id:data.id
+        id:data.id,
+        json:data.json
        }
     });
 });
@@ -585,7 +586,8 @@ ipcMain.on('sendImage', async(event,data) => {
   const targetWindow = BrowserWindow.fromWebContents(event.sender).getParentWindow();
   targetWindow.webContents.send('setImage', {
     id:data.id,
-    data:data.data
+    data:data.data,
+    json:data.json
   });
   BrowserWindow.fromWebContents(event.sender).close();
 });

--- a/scripts/imageeditor.js
+++ b/scripts/imageeditor.js
@@ -8,36 +8,62 @@ class ImageEditor{
 
     constructor({data}){
         this.data = data.image;
+        this.jsonData = data.json;
+        this.element=undefined;
         this.id=Math.random().toString(32).substring(2);
     }
 
     render(){
-        if(this.data){
+        if(this.data&&!(this.jsonData)){
             const div = document.createElement('div');
             div.id=this.id;
             const img = document.createElement('img');
             img.setAttribute("src",this.data);
             img.setAttribute("style","width: 100%; height: auto; display: block;");
             div.appendChild(img);
+            this.element=div;
+            return div;
+        }else if(this.jsonData){
+            const div = document.createElement('div');
+            div.id=this.id;
+            const img = document.createElement('img');
+            img.setAttribute("src",this.data);
+            img.setAttribute("data-json",this.jsonData);
+            img.setAttribute("style","width: 100%; height: auto; display: block;");
+            img.addEventListener("dblclick", (event) =>  {
+                window.noteAPI.openImageEditor({
+                    id:this.id,
+                    json:event.currentTarget.getAttribute('data-json')
+                });
+            });
+            div.appendChild(img);
+            this.element=div;
             return div;
         }else{
             window.noteAPI.openImageEditor({
-                id:this.id
+                id:this.id,
+                json:""
             });
             const div = document.createElement('div');
             div.id=this.id;
             const img = document.createElement('img');
             img.setAttribute("src","undifined");
             img.setAttribute("style","width: 100%; height: auto; display: block;");
+            img.addEventListener("dblclick", (event) =>  {
+                window.noteAPI.openImageEditor({
+                    id:this.id,
+                    json:event.currentTarget.getAttribute('data-json')
+                });
+            });
             div.appendChild(img);
+            this.element=div;
             return div;
         }
         
     }
 
     save(data){
-        const element = document.getElementById(this.id);
-        const img = element.querySelector('img');
+        const img = this.element.querySelector('img');
         const src = img.src;
         return {
             image:src,

--- a/scripts/imageeditor.js
+++ b/scripts/imageeditor.js
@@ -40,7 +40,8 @@ class ImageEditor{
         const img = element.querySelector('img');
         const src = img.src;
         return {
-            image:src
+            image:src,
+            json:img.getAttribute('data-json')
         }
     }
 

--- a/scripts/note_render.js
+++ b/scripts/note_render.js
@@ -168,6 +168,7 @@ window.noteAPI.setImage((_event, value) => {
     let element = document.getElementById(value.id);
     let img = element.querySelector('img');
     img.setAttribute("src",value.data);
+    img.setAttribute("data-json",JSON.stringify(value.json))
 });
 
 window.noteAPI.resetUnsaveFlag((_event, value) => {

--- a/scripts/note_render.js
+++ b/scripts/note_render.js
@@ -111,9 +111,7 @@ async function saveNewFile(){
     const inputNameElement=document.getElementById("inputName");
     let jsonData;
     await editor.save().then((outputData) => {
-        console.log(JSON.stringify(outputData, null , "\t"));
         jsonData=JSON.stringify(outputData, null , "\t");
-        console.log(jsonData);
     }).catch((error) => {
         console.log('Saving failed: ', error)
     });
@@ -126,7 +124,6 @@ async function saveNewFile(){
         left:document.getElementById("leftHead").value,
     };
     id=await window.noteAPI.newSave(data);
-    console.log(id);
     const titleData={
         windowid:windowID,
         title:inputNameElement.value
@@ -170,7 +167,6 @@ window.noteAPI.onPrint((_event, value) => {
 window.noteAPI.setImage((_event, value) => {
     let element = document.getElementById(value.id);
     let img = element.querySelector('img');
-    console.log(value.data);
     img.setAttribute("src",value.data);
 });
 


### PR DESCRIPTION
Previously, only base64-encoded webp images were saved after editing. Now, by also saving the JSON obtained through the export functionality of fabric.js, it's possible to redo edits by double-clicking even after an image has been embedded.